### PR TITLE
Fix: Preserve crucial settings across init() and receiveSettings callbacks

### DIFF
--- a/packages/components/plugin-bridge-provider/src/Provider.tsx
+++ b/packages/components/plugin-bridge-provider/src/Provider.tsx
@@ -78,7 +78,10 @@ const PluginBridgeProvider = ({
       },
       receiveSettings(settings) {
         console.log("receiveSettings", settings);
-        setBridgeSettings(settings);
+        setBridgeSettings((prevSettings) => ({
+          ...(prevSettings ?? {}),
+          ...settings,
+        }));
       },
       receiveValidation(validation) {
         console.log("receiveValidation", validation);


### PR DESCRIPTION
**PR Description:**  
This PR addresses an issue where the `receiveSettings` callback was unintentionally overwriting or wiping out the settings initialized in the `INIT` callback. As a result, important key values like `env`, `imsAccessToken`, and others were being lost, causing unintended behavior in subsequent operations. 

### Fix:  
- Ensured that the `receiveSettings` callback properly merges or retains the existing settings instead of replacing them entirely.
- Preserved crucial keys like `env` and `imsAccessToken` to maintain consistency across callbacks.

This change prevents configuration loss, ensuring smooth transitions between the initialization and settings callbacks.

### Before
<img width="854" alt="image" src="https://github.com/user-attachments/assets/194f86bf-3301-477f-a134-91ae47ca0af6">


### After
<img width="853" alt="image" src="https://github.com/user-attachments/assets/2a51ef0d-2624-4e9e-8499-5f91e48b89cb">
